### PR TITLE
Improved accessibility of the comment form

### DIFF
--- a/_includes/partials/post-new-comment.html
+++ b/_includes/partials/post-new-comment.html
@@ -4,11 +4,11 @@
     <input type="hidden" name="options[origin]" value="{{ site.url }}{{ page.url }}">
     
     <input type="text" name="company" class="text-field" style="display: none">
-    <input class="form__field text-field" type="text" name="fields[name]" placeholder="Name" required/>
-    <input class="form__field text-field" type="email" name="fields[email]" placeholder="Email address (will not be public)" required/>
-    <input class="form__field text-field" type="url" name="fields[url]" placeholder="Website (optional)"/>
+    <label><input class="form__field text-field" type="text" name="fields[name]" placeholder="Name" required>Name</label>
+    <label><input class="form__field text-field" type="email" name="fields[email]" placeholder="Email address (will not be public)" required>Email</label>
+    <label><input class="form__field text-field" type="url" name="fields[url]" placeholder="Website (optional)">Website</label>
     <input class="form__field text-field" type="address" name="fields[address]" placeholder="Address (do not fill!)" style="display: none"/>
-    <textarea class="form__field text-field" rows="10" name="fields[message]" placeholder="Comment. Markdown is accepted." required></textarea>
+    <label><textarea class="form__field text-field" rows="10" name="fields[message]" placeholder="Comment. Markdown is accepted." required></textarea>Comment. Markdown is accepted</label>
     <input id="form-subscribe" type="checkbox" name="options[subscribe]" value="email" class="checkbox">
     <label for="form-subscribe" class="form__field checkbox__label">I want to be notified of new comments</label>
     <input class="cta" type="submit" value="Send" />


### PR DESCRIPTION
Some considerations:
I put the `<label>` surrounding the `<input>`, as in the staticman docs. I can change that if you wish. Also, I haven't labeled the elements which don't require input; I don't know if that's correct.

Side note: I don't know what you were trying to achieve with hiding checkboxes, but please don't do that. Screen readers rely on the roles of elements to convey meaning and navigation. For instance, using my current OS / Screen Reader, I can normally press X to navigate to the next checkbox, and hear its state and if it changes. Now, as you've hidden it, the checkbox is reported as "clickable", I can't navigate to it using keyboard shortcuts, and I must see if there is an X appended to it.
This may be solved by either not hiding the checkbox, or by using WAI-ARIA: `role = checkbox` and state (checked or unchecked, which you should track using Javascript).
